### PR TITLE
Add server side Diffie-Hellman minimum modulus len

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Once you've got your list, add it to your GPO and roll it out!
 * [Schannel Cipher Suites in Windows Server 2008 R2 and above][2008r2]
 * [How to restrict the use of certain cryptographic algorithms and protocols in Schannel.dll][restrict_usage]
 * [Managing Group Policy ADMX Files Step-by-Step Guide][admx_install]
-
+* [Transport Layer Security (TLS) registry settings][TLS_registry]
 
 [IISCrypto]: https://www.nartac.com/Products/IISCrypto
 [policies]: https://msdn.microsoft.com/en-us/library/aa374292(v=vs.85).aspx
@@ -148,3 +148,4 @@ Once you've got your list, add it to your GPO and roll it out!
 [vista]: https://msdn.microsoft.com/en-us/library/windows/desktop/ff468651(v=vs.85).aspx
 [2008r2]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa374757(v=vs.85).aspx
 [restrict_usage]: https://support.microsoft.com/en-us/kb/245030
+[TLS_registry]: https://docs.microsoft.com/en-us/windows-server/security/tls/tls-registry-settings

--- a/template/en-US/schannel.adml
+++ b/template/en-US/schannel.adml
@@ -10,6 +10,9 @@
     <description>This file contains settings for enabling or disabling TLS and SSL versions.</description>
     <resources>
         <stringTable>
+            <string id="SUPPORTED_3174644">At least Windows 10; 
+At least Windows Server 2008 SP2 or Windows Vista SP2 with KB3174644 </string>
+
             <!-- CATEGORIES -->
             <string id="Protocols">Protocols</string>
             <string id="WeakProtocols">Weak Protocols</string>
@@ -326,8 +329,11 @@ TLS_DHE_DSS_WITH_AES_128_CBC_SHA256
 TLS_DHE_DSS_WITH_AES_256_CBC_SHA
 TLS_DHE_DSS_WITH_AES_256_CBC_SHA256
 TLS_DHE_DSS_WITH_DES_CBC_SHA
+            </string>
+            <string id="DHServer">Diffie-Hellman Server-side Key Shares</string>
+            <string id="DHServer_Help">Sets the minimum Diffie-Hellman ephemeral key shares for TLS servers.
 
-Please see KB3174644 for more information on DH modulus length. 2048 is the currently recommended value.
+Please see Microsoft Security Advisory 3174644 for more information on DH modulus length. 2048 is the currently recommended minimum value.
             </string>
             <string id="DH_Value1024">1024</string>
             <string id="DH_Value2048">2048</string>
@@ -392,8 +398,8 @@ If this setting is left unconfigured, TLS 1.1 and TLS 1.2 will be disabled by de
 
         <presentationTable>
             <!-- KEY EXCHANGE ALGORITHMS -->
-            <presentation id="DH">
-              <dropdownList refId="DH_ServerMinKeyBitLength">Server side DH modulus length</dropdownList>
+            <presentation id="DHServer">
+              <dropdownList refId="DHServer_MinLength">Server side DH modulus minimum length</dropdownList>
             </presentation>
 
             <!-- PROTOCOLS -->

--- a/template/en-US/schannel.adml
+++ b/template/en-US/schannel.adml
@@ -326,7 +326,13 @@ TLS_DHE_DSS_WITH_AES_128_CBC_SHA256
 TLS_DHE_DSS_WITH_AES_256_CBC_SHA
 TLS_DHE_DSS_WITH_AES_256_CBC_SHA256
 TLS_DHE_DSS_WITH_DES_CBC_SHA
+
+Please see KB3174644 for more information on DH modulus length. 2048 is the currently recommended value.
             </string>
+            <string id="DH_Value1024">1024</string>
+            <string id="DH_Value2048">2048</string>
+            <string id="DH_Value3072">3072</string>
+            <string id="DH_Value4096">4096</string>
 
             <!-- PKCS -->
             <string id="PKCS">PKCS</string>
@@ -381,9 +387,15 @@ If this setting is left unconfigured, TLS 1.1 and TLS 1.2 will be enabled by def
 
 If this setting is left unconfigured, TLS 1.1 and TLS 1.2 will be disabled by default.
             </string>
+
         </stringTable>
 
         <presentationTable>
+            <!-- KEY EXCHANGE ALGORITHMS -->
+            <presentation id="DH">
+              <dropdownList refId="DH_ServerMinKeyBitLength">Server side DH modulus length</dropdownList>
+            </presentation>
+
             <!-- PROTOCOLS -->
             <presentation id="MPUH">
                 <checkBox refId="MPUH_ClientCheckbox" defaultChecked="false">Enable Client-side Multi-Protocol Unified Hello (eg., Internet Explorer)</checkBox>

--- a/template/schannel.admx
+++ b/template/schannel.admx
@@ -634,6 +634,7 @@
         <!-- Diffie-Hellman -->
         <policy name="DH" class="Machine" displayName="$(string.DH)"
                 explainText="$(string.DH_Help)"
+                presentation="$(presentation.DH)"
                 valueName="Enabled"
                 key="SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\KeyExchangeAlgorithms\Diffie-Hellman">
             <parentCategory ref="KeyEx" />
@@ -644,6 +645,30 @@
             <disabledValue>
                 <decimal value="0" />
             </disabledValue>
+            <elements>
+                <enum id="DH_ServerMinKeyBitLength" valueName="ServerMinKeyBitLength" >
+                    <item displayName="$(string.DH_Value1024)" >
+                        <value>
+                            <decimal value="1024" />
+                        </value>
+                    </item>
+                    <item displayName="$(string.DH_Value2048)">
+                        <value>
+                            <decimal value="2048" />
+                        </value>
+                    </item>
+                    <item displayName="$(string.DH_Value3072)">
+                        <value>
+                            <decimal value="3072" />
+                        </value>
+                    </item>
+                    <item displayName="$(string.DH_Value4096)">
+                        <value>
+                            <decimal value="4096" />
+                        </value>
+                    </item>
+                </enum>
+            </elements>
         </policy>
 
         <!-- PKCS -->
@@ -676,7 +701,7 @@
             </disabledValue>
         </policy>
 
-            <!-- .NET Framework 4 -->
+        <!-- .NET Framework 4 -->
         <policy name="dotnet4" class="Machine" displayName="$(string.dotnet4)"
                 explainText="$(string.dotnet4_Help)"
                 key="SOFTWARE\Microsoft\.NETFramework\v4.0.30319">

--- a/template/schannel.admx
+++ b/template/schannel.admx
@@ -8,6 +8,17 @@
         <using prefix="cypherstrength" namespace="Microsoft.Policies.CypherStrength" />
     </policyNamespaces>
     <resources minRequiredRevision="1.0" />
+    <supportedOn>
+        <definitions>
+            <definition name="SUPPORTED_3174644" displayName="$(string.SUPPORTED_3174644)">
+              <or>
+                  <range ref="products:MicrosoftWindows" minVersionIndex="4"/>
+                  <range ref="products:WindowsServer2008" minVersionIndex="2"/>
+                  <range ref="products:MicrosoftWindowsVista" minVersionIndex="2"/>
+              </or>
+          </definition>
+      </definitions>
+    </supportedOn>
     <categories>
         <category name="Protocols" displayName="$(string.Protocols)">
             <parentCategory ref="cypherstrength:SSLConfiguration" />
@@ -634,7 +645,6 @@
         <!-- Diffie-Hellman -->
         <policy name="DH" class="Machine" displayName="$(string.DH)"
                 explainText="$(string.DH_Help)"
-                presentation="$(presentation.DH)"
                 valueName="Enabled"
                 key="SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\KeyExchangeAlgorithms\Diffie-Hellman">
             <parentCategory ref="KeyEx" />
@@ -645,8 +655,15 @@
             <disabledValue>
                 <decimal value="0" />
             </disabledValue>
+        </policy>
+        <policy name="DHServer" class="Machine" displayName="$(string.DHServer)"
+                explainText="$(string.DHServer_Help)"
+                presentation="$(presentation.DHServer)"
+                key="SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\KeyExchangeAlgorithms\Diffie-Hellman">
+            <parentCategory ref="KeyEx" />
+            <supportedOn ref="SUPPORTED_3174644" />
             <elements>
-                <enum id="DH_ServerMinKeyBitLength" valueName="ServerMinKeyBitLength" >
+                <enum id="DHServer_MinLength" valueName="ServerMinKeyBitLength" >
                     <item displayName="$(string.DH_Value1024)" >
                         <value>
                             <decimal value="1024" />


### PR DESCRIPTION
Hello.

I have found a new document for TLS registry settings at https://docs.microsoft.com/en-us/windows-server/security/tls/tls-registry-settings , which I have added to the list of resources.
Based on this document I have added a new setting for server side Diffie-Hellman minimum modulus length, which Microsoft recommends to set to 2048 bits.

Can you please accept the change?

BR Igor