### PR TITLE
DH & PKCS ClientMinKeyBitLength and WinHTTP TLS settings

### DIFF
--- a/template/en-US/schannel.adml
+++ b/template/en-US/schannel.adml
@@ -335,6 +335,11 @@ TLS_DHE_DSS_WITH_DES_CBC_SHA
 
 Please see Microsoft Security Advisory 3174644 for more information on DH modulus length. 2048 is the currently recommended minimum value.
             </string>
+            <string id="DHClient">Diffie-Hellman Client-side Key Size</string>
+            <string id="DHClient_Help">Sets the minimum Diffie-Hellman ephemeral key size for TLS Client.
+
+Please see Microsoft Security Advisory 3174644 for more information on DH modulus length. 1024 is the currently recommended minimum value.
+            </string>			
             <string id="DH_Value1024">1024</string>
             <string id="DH_Value2048">2048</string>
             <string id="DH_Value3072">3072</string>
@@ -343,6 +348,15 @@ Please see Microsoft Security Advisory 3174644 for more information on DH modulu
             <!-- PKCS -->
             <string id="PKCS">PKCS</string>
             <string id="PKCS_Help">Enables or disables the use of the PKCS key exchange algorithm.</string>
+            <string id="PKCSClient">PKCS Client-side Key Size</string>
+            <string id="PKCSClient_Help">Sets the minimum PKCS ephemeral key size for TLS Client.
+
+Please see Microsoft Security Advisory 3174644 or https://support.microsoft.com/en-us/help/3174644/microsoft-security-advisory-updated-support-for-diffie-hellman-key-exc for more information on PKCS modulus length. 1024 is the currently recommended minimum value.
+            </string>	
+            <string id="PKCS_Value1024">1024</string>
+            <string id="PKCS_Value2048">2048</string>
+            <string id="PKCS_Value3072">3072</string>
+            <string id="PKCS_Value4096">4096</string>
 
             <!-- ECDH -->
             <string id="ECDH">ECDH</string>
@@ -401,7 +415,12 @@ If this setting is left unconfigured, TLS 1.1 and TLS 1.2 will be disabled by de
             <presentation id="DHServer">
               <dropdownList refId="DHServer_MinLength">Server side DH modulus minimum length</dropdownList>
             </presentation>
-
+            <presentation id="DHClient">
+              <dropdownList refId="DHClient_MinLength">Client side DH modulus minimum length</dropdownList>
+            </presentation>
+            <presentation id="PKCSClient">
+              <dropdownList refId="PKCSClient_MinLength">Client side PKCS modulus minimum length</dropdownList>
+            </presentation>			
             <!-- PROTOCOLS -->
             <presentation id="MPUH">
                 <checkBox refId="MPUH_ClientCheckbox" defaultChecked="false">Enable Client-side Multi-Protocol Unified Hello (eg., Internet Explorer)</checkBox>

--- a/template/schannel.admx
+++ b/template/schannel.admx
@@ -687,6 +687,37 @@
                 </enum>
             </elements>
         </policy>
+        <policy name="DHClient" class="Machine" displayName="$(string.DHClient)"
+                explainText="$(string.DHClient_Help)"
+                presentation="$(presentation.DHClient)"
+                key="SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\KeyExchangeAlgorithms\Diffie-Hellman">
+            <parentCategory ref="KeyEx" />
+            <supportedOn ref="SUPPORTED_3174644" />
+            <elements>
+                <enum id="DHClient_MinLength" valueName="ClientMinKeyBitLength" >
+                    <item displayName="$(string.DH_Value1024)" >
+                        <value>
+                            <decimal value="1024" />
+                        </value>
+                    </item>
+                    <item displayName="$(string.DH_Value2048)">
+                        <value>
+                            <decimal value="2048" />
+                        </value>
+                    </item>
+                    <item displayName="$(string.DH_Value3072)">
+                        <value>
+                            <decimal value="3072" />
+                        </value>
+                    </item>
+                    <item displayName="$(string.DH_Value4096)">
+                        <value>
+                            <decimal value="4096" />
+                        </value>
+                    </item>
+                </enum>
+            </elements>
+        </policy>
 
         <!-- PKCS -->
         <policy name="PKCS" class="Machine" displayName="$(string.PKCS)"
@@ -701,6 +732,37 @@
             <disabledValue>
                 <decimal value="0" />
             </disabledValue>
+        </policy>
+        <policy name="PKCSClient" class="Machine" displayName="$(string.PKCSClient)"
+                explainText="$(string.PKCSClient_Help)"
+                presentation="$(presentation.PKCSClient)"
+                key="SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\KeyExchangeAlgorithms\PKCS">
+            <parentCategory ref="KeyEx" />
+            <supportedOn ref="SUPPORTED_3174644" />
+            <elements>
+                <enum id="PKCSClient_MinLength" valueName="ClientMinKeyBitLength" >
+                    <item displayName="$(string.PKCS_Value1024)" >
+                        <value>
+                            <decimal value="1024" />
+                        </value>
+                    </item>
+                    <item displayName="$(string.PKCS_Value2048)">
+                        <value>
+                            <decimal value="2048" />
+                        </value>
+                    </item>
+                    <item displayName="$(string.PKCS_Value3072)">
+                        <value>
+                            <decimal value="3072" />
+                        </value>
+                    </item>
+                    <item displayName="$(string.PKCS_Value4096)">
+                        <value>
+                            <decimal value="4096" />
+                        </value>
+                    </item>
+                </enum>
+            </elements>
         </policy>
 
         <!-- Elliptic-Curve Diffie-Hellman -->


### PR DESCRIPTION
Hi,

I normally use [this](https://www.hass.de/content/setup-microsoft-windows-or-iis-ssl-perfect-forward-secrecy-and-tls-12) powershell script to setup Schannel but i'd like to migrate this over to GPO to make it easier for some of my colleagues to maintain and deploy this to clients. Using this ADMX I got pretty far but it was missing a few things.

I added ClientMinKeyBitLength for both DH and PKCS. 

The other thing that is missing is an options to set WinHTTP default TLS settings. 
```
# Update to enable TLS 1.1 and TLS 1.2 as a default secure protocols in WinHTTP in Windows
# https://support.microsoft.com/en-us/help/3140245/update-to-enable-tls-1-1-and-tls-1-2-as-a-default-secure-protocols-in
# Verify if hotfix KB3140245 is installed.
if ([System.Version](Get-Item $env:windir\system32\Webio.dll).VersionInfo.ProductVersion -lt [System.Version]"6.1.7601.23375" -or [System.Version](Get-Item $env:windir\system32\Winhttp.dll).VersionInfo.ProductVersion -lt [System.Version]"6.1.7601.23375") {
  Write-Host 'WinHTTP: Cannot enable TLS 1.1 and TLS 1.2. Please see https://support.microsoft.com/en-us/help/3140245/update-to-enable-tls-1-1-and-tls-1-2-as-a-default-secure-protocols-in for system requirements.'
} else {
  Write-Host 'WinHTTP: Minimum system requirements are met.'
 
  # DefaultSecureProtocols Value	Decimal value  Protocol enabled
  # 0x00000008                                8  Enable SSL 2.0 by default
  # 0x00000020                               32  Enable SSL 3.0 by default
  # 0x00000080                              128  Enable TLS 1.0 by default
  # 0x00000200                              512  Enable TLS 1.1 by default
  # 0x00000800                             2048  Enable TLS 1.2 by default
  $defaultSecureProtocols = @(
    '128',  # TLS 1.0
    '512',  # TLS 1.1
    '2048'  # TLS 1.2
  )
  $defaultSecureProtocolsSum = ($defaultSecureProtocols | Measure-Object -Sum).Sum
 
  Write-Host 'WinHTTP: Activate TLS 1.0, TLS 1.1 and TLS 1.2 only.'
  New-ItemProperty -path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Internet Settings\WinHttp' -name 'DefaultSecureProtocols' -value $defaultSecureProtocolsSum -PropertyType 'DWord' -Force | Out-Null
  if (Test-Path 'HKLM:\SOFTWARE\Wow6432Node') {
    New-ItemProperty -path 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Internet Settings\WinHttp' -name 'DefaultSecureProtocols' -value $defaultSecureProtocolsSum -PropertyType 'DWord' -Force | Out-Null
  }
```
I'm not really well versed in the creation of ADMX files but I guess 
`<supportedOn ref="SUPPORTED_3140245" />`
would suffice as setting up the dependency of KB3140245? 

No idea, apart from using WMI filters, to check for 64bit (`HKLM:\SOFTWARE\Wow6432Node`) though.