### PR TITLE
Update and reorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Group Policy to do just that.
 be out of date. If you notice something that needs to be updated, please
 submit an issue or a pull request!*
 
-***Note**: PedroAsani here, I decided to take this and do some updates since Crosse has said they no longer will. The first is to move TLS 1.0 into Weak Protocols, MD5 and SHA-1 into Weak Hash Algorithms, Triple-DES into Weak Ciphers, and Diffie-Hellman into Weak Key Exchange Algorithms. I'll be doing similar changes to bring the use of the settings in line with Best Practice and their placement will be based entirely on known vulnerabilities. I will not be changing default behavior on any at this time.*
-
 # What Does it Do?
 This template simply twiddles values under the registry key
 `HKLM\CurrentControlSet\Control\SecurityProviders\Schannel`.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ startup script GPO, but I wanted a more Group Policy-integrated way to
 enable or disable things.  So I created an administrative template for
 Group Policy to do just that.
 
-***Note***: I no longer maintain Windows servers for my job, so this may
+***Note**: I no longer maintain Windows servers for my job, so this may
 be out of date. If you notice something that needs to be updated, please
 submit an issue or a pull request!*
 
-***Note***: PedroAsani here, I decided to take this and do some updates since Crosse has said they no longer will. The first is to move TLS 1.0 into Weak Protocols, MD5 and SHA-1 into Weak Hash Algorithms, Triple-DES into Weak Ciphers, and Diffie-Hellman into Weak Key Exchange Algorithms. I'll be doing similar changes to bring the use of the settings in line with Best Practice and their placement will be based entirely on known vulnerabilities. I will not be changing default behavior on any at this time.
+***Note**: PedroAsani here, I decided to take this and do some updates since Crosse has said they no longer will. The first is to move TLS 1.0 into Weak Protocols, MD5 and SHA-1 into Weak Hash Algorithms, Triple-DES into Weak Ciphers, and Diffie-Hellman into Weak Key Exchange Algorithms. I'll be doing similar changes to bring the use of the settings in line with Best Practice and their placement will be based entirely on known vulnerabilities. I will not be changing default behavior on any at this time.*
 
 # What Does it Do?
 This template simply twiddles values under the registry key

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Group Policy to do just that.
 be out of date. If you notice something that needs to be updated, please
 submit an issue or a pull request!*
 
-***Note***: PedroAsani here, I decided to take this and do some updates since Crosse has said they no longer will. The first is to move TLS 1.0 into Weak Protocols. I'll be doing similar changes to bring the use of the settings in line with Best Practice and their placement will be based entirely on known vulnerabilities.
+***Note***: PedroAsani here, I decided to take this and do some updates since Crosse has said they no longer will. The first is to move TLS 1.0 into Weak Protocols, MD5 and SHA-1 into Weak Hash Algorithms, Triple-DES into Weak Ciphers, and Diffie-Hellman into Weak Key Exchange Algorithms. I'll be doing similar changes to bring the use of the settings in line with Best Practice and their placement will be based entirely on known vulnerabilities. I will not be changing default behavior on any at this time.
 
 # What Does it Do?
 This template simply twiddles values under the registry key
@@ -72,7 +72,6 @@ immediately when the group policy is applied.  Changes to protocols
 require a restart of the computer.
 
 ## Ciphers
-* [Triple DES 168](https://en.wikipedia.org/wiki/Triple_DES)
 * [AES 128/128](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard)
 * [AES 256/256](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard)
 
@@ -86,18 +85,23 @@ require a restart of the computer.
 * [RC4 56/128](https://en.wikipedia.org/wiki/RC4)
 * [RC4 64/128](https://en.wikipedia.org/wiki/RC4)
 * [RC4 128/128](https://en.wikipedia.org/wiki/RC4)
+* [Triple DES 168](https://en.wikipedia.org/wiki/Triple_DES)
 
 ## Hash Algorithms
-* [MD5](https://en.wikipedia.org/wiki/MD5)
-* [SHA](https://en.wikipedia.org/wiki/SHA-1) (also called "SHA-1")
 * [SHA-256](https://en.wikipedia.org/wiki/SHA-2)
 * [SHA-384](https://en.wikipedia.org/wiki/SHA-2)
 * [SHA-512](https://en.wikipedia.org/wiki/SHA-2)
 
+### Hash Algorithms\Weak Hash Algorithms
+* [MD5](https://en.wikipedia.org/wiki/MD5)
+* [SHA](https://en.wikipedia.org/wiki/SHA-1) (also called "SHA-1")
+
 ## Key Exchange Algorithms
-* [Diffie-Hellman (DH)](https://en.wikipedia.org/wiki/Diffie–Hellman_key_exchange)
 * [PKCS](https://en.wikipedia.org/wiki/PKCS)
 * [Elliptic-Curve Diffie-Hellman (ECDH)](https://en.wikipedia.org/wiki/Elliptic_curve_Diffie–Hellman)
+
+### Key Exchange Algorithms\Weak Key Exchange Algorithms
+* [Diffie-Hellman (DH)](https://en.wikipedia.org/wiki/Diffie–Hellman_key_exchange)
 
 ## Protocols
 * [TLS 1.1](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.1)

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ startup script GPO, but I wanted a more Group Policy-integrated way to
 enable or disable things.  So I created an administrative template for
 Group Policy to do just that.
 
-***Note**: I no longer maintain Windows servers for my job, so this may
+***Note***: I no longer maintain Windows servers for my job, so this may
 be out of date. If you notice something that needs to be updated, please
 submit an issue or a pull request!*
+
+***Note***: PedroAsani here, I decided to take this and do some updates since Crosse has said they no longer will. The first is to move TLS 1.0 into Weak Protocols. I'll be doing similar changes to bring the use of the settings in line with Best Practice and their placement will be based entirely on known vulnerabilities.
 
 # What Does it Do?
 This template simply twiddles values under the registry key
@@ -98,7 +100,6 @@ require a restart of the computer.
 * [Elliptic-Curve Diffie-Hellman (ECDH)](https://en.wikipedia.org/wiki/Elliptic_curve_Diffie–Hellman)
 
 ## Protocols
-* [TLS 1.0](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.0)
 * [TLS 1.1](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.1)
 * [TLS 1.2](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.2)
 
@@ -107,6 +108,7 @@ require a restart of the computer.
 * [PCT 1.0](https://en.wikipedia.org/wiki/Private_Communications_Technology)
 * [SSL 2.0](https://en.wikipedia.org/wiki/Transport_Layer_Security#SSL_1.0.2C_2.0_and_3.0)
 * [SSL 3.0](https://en.wikipedia.org/wiki/Transport_Layer_Security#SSL_1.0.2C_2.0_and_3.0)
+* [TLS 1.0](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.0)
 
 ## Cipher Suite Order
 Setting the cipher suite order (the second half of IIS Crypto) for

--- a/template/en-US/schannel.adml
+++ b/template/en-US/schannel.adml
@@ -19,7 +19,9 @@ At least Windows Server 2008 SP2 or Windows Vista SP2 with KB3174644 </string>
             <string id="Ciphers">Ciphers</string>
             <string id="WeakCiphers">Weak Ciphers</string>
             <string id="Hashes">Hashes</string>
+            <string id="WeakHashes">Weak Hashes</string>
             <string id="KeyEx">Key Exchanges</string>
+            <string id="WeakKeyEx">Weak Key Exchanges</string>
 
 
             <!-- PROTOCOLS -->

--- a/template/schannel.admx
+++ b/template/schannel.admx
@@ -527,7 +527,7 @@
                 explainText="$(string.3DES_Help)"
                 valueName="Enabled"
                 key="SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Ciphers\Triple DES 168">
-            <parentCategory ref="Ciphers" />
+            <parentCategory ref="WeakCiphers" />
             <supportedOn ref="windows:SUPPORTED_WindowsUpdate" />
             <enabledValue>
                 <decimal value="4294967295" />
@@ -575,7 +575,7 @@
                 explainText="$(string.MD5_Help)"
                 valueName="Enabled"
                 key="SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Hashes\MD5">
-            <parentCategory ref="Hashes" />
+            <parentCategory ref="WeakHashes" />
             <supportedOn ref="windows:SUPPORTED_WindowsNET" />
             <enabledValue>
                 <decimal value="4294967295" />
@@ -590,7 +590,7 @@
                 explainText="$(string.SHA_Help)"
                 valueName="Enabled"
                 key="SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Hashes\SHA">
-            <parentCategory ref="Hashes" />
+            <parentCategory ref="WeakHashes" />
             <supportedOn ref="windows:SUPPORTED_WindowsNET" />
             <enabledValue>
                 <decimal value="4294967295" />

--- a/template/schannel.admx
+++ b/template/schannel.admx
@@ -241,7 +241,7 @@
                 explainText="$(string.TLSv10_Help)"
                 presentation="$(presentation.TLSv10)"
                 key="SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0">
-            <parentCategory ref="Protocols" />
+            <parentCategory ref="WeakProtocols" />
             <supportedOn ref="windows:SUPPORTED_Win2k" />
             <elements>
                 <boolean id="TLSv10_ClientCheckbox" key="SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.0\Client" valueName="">

--- a/template/schannel.admx
+++ b/template/schannel.admx
@@ -35,8 +35,14 @@
         <category name="Hashes" displayName="$(string.Hashes)">
             <parentCategory ref="cypherstrength:SSLConfiguration" />
         </category>
+        <category name="WeakHashes" displayName="$(string.WeakHashes)">
+            <parentCategory ref="schannel:Hashes" />
+        </category>
         <category name="KeyEx" displayName="$(string.KeyEx)">
             <parentCategory ref="cypherstrength:SSLConfiguration" />
+        </category>
+        <category name="WeakKeyEx" displayName="$(string.WeakKeyEx)">
+            <parentCategory ref="schannel:KeyEx" />
         </category>
     </categories>
 

--- a/template/schannel.admx
+++ b/template/schannel.admx
@@ -325,7 +325,6 @@
                         </item>
                     </trueList>
                     <falseList defaultKey="SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.1\Server">
-                        <item valueName=""><value><decimal value="" /></value></item>
                         <item valueName="Enabled">
                             <value><decimal value="0" /></value>
                         </item>


### PR DESCRIPTION
I decided to take this and do some updates since Crosse has said they no longer will. The first is to move TLS 1.0 into Weak Protocols, MD5 and SHA-1 into Weak Hash Algorithms, Triple-DES into Weak Ciphers, and Diffie-Hellman into Weak Key Exchange Algorithms. I'll be doing similar changes to bring the use of the settings in line with Best Practice and their placement will be based entirely on known vulnerabilities. I will not be changing default behavior on any at this time.* 