### PR TITLE
Add install batch

### DIFF
--- a/Install-Silent.cmd
+++ b/Install-Silent.cmd
@@ -1,0 +1,9 @@
+@echo off
+call :InstallInFolder "%SYSTEMROOT%\PolicyDefinitions"
+if exist "%SYSTEMROOT%\sysvol\domain\policies\PolicyDefinitions" call :InstallInFolder "%SYSTEMROOT%\sysvol\domain\policies\PolicyDefinitions"
+goto :EOF
+
+:InstallInFolder
+echo Copying to %1
+copy /y "%~dp0*.admx" %1
+for /d %%l in ("%~1\*") do copy /y "%~dp0%%~nl\*.adml" %%l


### PR DESCRIPTION
Created an install batch to avoid issues like #21 (and support my laziness :).
Consider if the batch file should be located in the same directory as the templates. OTOH placing it a directory higher would place is in the repo base, which is also not the best option... what is your opinion?