### PR TITLE
Add default item selection for DH key exchange (2048 bits)

### DIFF
--- a/template/de-DE/schannel.adml
+++ b/template/de-DE/schannel.adml
@@ -444,13 +444,13 @@ https://docs.microsoft.com/de-DE/dotnet/framework/network-programming/tls
         <presentationTable>
             <!-- KEY EXCHANGE ALGORITHMS -->
             <presentation id="DHServer">
-              <dropdownList refId="DHServer_MinLength">Serverseitinge minimale DH-Modulus-Länge</dropdownList>
+              <dropdownList refId="DHServer_MinLength" defaultItem="1">Serverseitinge minimale DH-Modulus-Länge</dropdownList>
             </presentation>
             <presentation id="DHClient">
-              <dropdownList refId="DHClient_MinLength">Clientseitige minimale DH-Modulus-Länge</dropdownList>
+              <dropdownList refId="DHClient_MinLength" defaultItem="1">Clientseitige minimale DH-Modulus-Länge</dropdownList>
             </presentation>
             <presentation id="PKCSClient">
-              <dropdownList refId="PKCSClient_MinLength">Clientseitige minimale PKCS-Modulus-Länge</dropdownList>
+              <dropdownList refId="PKCSClient_MinLength" defaultItem="1">Clientseitige minimale PKCS-Modulus-Länge</dropdownList>
             </presentation>
             <!-- PROTOCOLS -->
             <presentation id="MPUH">

--- a/template/en-US/schannel.adml
+++ b/template/en-US/schannel.adml
@@ -440,13 +440,13 @@ https://docs.microsoft.com/en-us/dotnet/framework/network-programming/tls
         <presentationTable>
             <!-- KEY EXCHANGE ALGORITHMS -->
             <presentation id="DHServer">
-              <dropdownList refId="DHServer_MinLength">Server side DH modulus minimum length</dropdownList>
+              <dropdownList refId="DHServer_MinLength" defaultItem="1">Server side DH modulus minimum length</dropdownList>
             </presentation>
             <presentation id="DHClient">
-              <dropdownList refId="DHClient_MinLength">Client side DH modulus minimum length</dropdownList>
+              <dropdownList refId="DHClient_MinLength" defaultItem="1">Client side DH modulus minimum length</dropdownList>
             </presentation>
             <presentation id="PKCSClient">
-              <dropdownList refId="PKCSClient_MinLength">Client side PKCS modulus minimum length</dropdownList>
+              <dropdownList refId="PKCSClient_MinLength" defaultItem="1">Client side PKCS modulus minimum length</dropdownList>
             </presentation>			
             <!-- PROTOCOLS -->
             <presentation id="MPUH">

--- a/template/fr-FR/schannel.adml
+++ b/template/fr-FR/schannel.adml
@@ -391,13 +391,13 @@ Si ce paramètre n'est pas configuré ou est désactivé, TLS 1.1 et 1.2 sont d�
 		<presentationTable>
 			<!-- KEY EXCHANGE ALGORITHMS -->
 			<presentation id="DHServer">
-				<dropdownList refId="DHServer_MinLength">Taille minimale du module DH côté serveur :</dropdownList>
+				<dropdownList refId="DHServer_MinLength" defaultItem="1">Taille minimale du module DH côté serveur :</dropdownList>
 			</presentation>
 			<presentation id="DHClient">
-				<dropdownList refId="DHClient_MinLength">Taille minimale du module DH côté client :</dropdownList>
+				<dropdownList refId="DHClient_MinLength" defaultItem="1">Taille minimale du module DH côté client :</dropdownList>
 			</presentation>
 			<presentation id="PKCSClient">
-				<dropdownList refId="PKCSClient_MinLength">Taille minimale du module PKCS côté client :</dropdownList>
+				<dropdownList refId="PKCSClient_MinLength" defaultItem="1">Taille minimale du module PKCS côté client :</dropdownList>
 			</presentation>
 			<!-- PROTOCOLS -->
 			<presentation id="MPUH">


### PR DESCRIPTION
Add a defaultItem parameter, pre-set to select a 2048 bits modulus for RSA (PKCS) and Diffie-Hellman key exchange mechanisms when the policy is set to Enabled